### PR TITLE
Run lint during CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,4 +22,5 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
+      - run: yarn lint
       - run: yarn test


### PR DESCRIPTION
Running eslint during the builds.  This will keep lint errors from creeping into our master branch. 