### PR TITLE
Adding contact details page

### DIFF
--- a/src/app/common/colors.js
+++ b/src/app/common/colors.js
@@ -1,4 +1,3 @@
-
 export const BLACK = '#000';
 export const WHITE = '#fff';
 export const DARK_GREY = '#333';

--- a/src/app/containers/Contacts/details.js
+++ b/src/app/containers/Contacts/details.js
@@ -1,7 +1,11 @@
 import React, {Component} from 'react';
 import { connect } from 'react-redux';
-import { View, Text } from 'react-native';
-import commonStyles from '../../common/styles';
+import { View, Text, TouchableWithoutFeedback, TouchableOpacity, Keyboard } from 'react-native';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+import FontAwesome, { Icons } from 'react-native-fontawesome';
+import {navigateToMap} from '../../actions/navigation';
+import styles from './styles';
 
 class ContactDetailsScreen extends Component {
   static navigationOptions = () => {
@@ -10,18 +14,60 @@ class ContactDetailsScreen extends Component {
       headerTitle: 'contact details'
     };
   };
+  _directToMap() {
+    this.props.navigateToMap();
+  }
+  viewTapped() {
+    Keyboard.dismiss();
+  }
 
   render() {
+    const {params} = this.props.navigation.state;
     return (
-      <View style={commonStyles.container}>
-        <Text>CONTACT DETAILS</Text>
-      </View>
+      <TouchableWithoutFeedback onPress={this.viewTapped.bind(this)}>
+        <View>
+          <View style = {styles.mainContainer}>
+            <Text style = {styles.titleWrapper}>{`${params.firstName} ${params.lastName}`}</Text>
+            <TouchableOpacity
+              onPress={() => this._directToMap() }>
+              <FontAwesome style={[styles.navIconWrapper]}>
+                {Icons.compass}
+                <View>
+                  <Text style = {styles.textWrapper}>     navigate to shared map </Text>
+                </View>
+              </FontAwesome>
+            </TouchableOpacity>
+          </View>
+          { params.phoneNumbers.map((item, key) => (
+            <View style = {styles.phoneContainer} key = {key}>
+              <Text style = {styles.containerText}>{item.label}</Text>
+              <Text style = {styles.containerValue}>{item.number}</Text>
+            </View>
+          ))}
+          <View style = {styles.lastcontactWrapper}>
+            <Text style = {styles.containerText}>Last Contact</Text>
+            <Text style = {styles.containerValue}> </Text>
+          </View>
+
+          <View>
+            <FontAwesome style={[styles.iconWrapper]}>
+              {Icons.userO}
+              <Text>  block user</Text>
+            </FontAwesome>
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
     );
   }
 }
-ContactDetailsScreen.propTypes = {};
+
+ContactDetailsScreen.propTypes = {
+  navigateToMap: PropTypes.func.isRequired
+};
 
 const mapStateToProps = state => (state);
-const mapDispatchToProps = () => ({});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({navigateToMap}, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ContactDetailsScreen);

--- a/src/app/containers/Contacts/index.js
+++ b/src/app/containers/Contacts/index.js
@@ -45,6 +45,7 @@ class ContactsScreen extends React.Component {
         return 0;
       })
     });
+    //console.log(this.state.contacts);
   }
 
   _getContactFullName(contact) {

--- a/src/app/containers/Contacts/styles.js
+++ b/src/app/containers/Contacts/styles.js
@@ -1,0 +1,57 @@
+import {StyleSheet} from 'react-native';
+import {PURPLE} from '../../common/colors';
+import {LIGHT_GREY} from '../../common/colors';
+import {MEDIUM_GREY} from '../../common/colors';
+import {BLACK} from '../../common/colors';
+
+const styles = StyleSheet.create({
+  mainContainer: {
+    marginTop: 50,
+    marginBottom: 30,
+    borderBottomWidth: 1,
+    borderBottomColor: LIGHT_GREY,
+    paddingBottom: 10
+  },
+  phoneContainer: {
+    padding: 15
+  },
+  titleWrapper: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    alignSelf: 'center',
+    marginBottom: 10
+  },
+  containerText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: MEDIUM_GREY,
+    padding:3
+  },
+  containerValue: {
+    padding: 5,
+    fontSize: 16,
+    color: BLACK
+  },
+  textWrapper: {
+    color: PURPLE,
+    fontSize: 20,
+    paddingStart: 10,
+  },
+  iconWrapper: {
+    marginTop: 10,
+    fontSize: 20,
+    paddingStart: 20,
+  },
+  lastcontactWrapper: {
+    padding: 15,
+    borderWidth: 1,
+    borderColor: LIGHT_GREY
+  },
+  navIconWrapper: {
+    fontSize: 25,
+    paddingStart: 20,
+    marginTop: 10
+  }
+});
+
+export default styles;

--- a/src/app/navigators/main.js
+++ b/src/app/navigators/main.js
@@ -19,7 +19,7 @@ export default createBottomTabNavigator({
     {
       [ScreenNames.CONTACTS]: {screen:ContactsScreen},
       [ScreenNames.CONTACT_DETAILS]: {screen:ContactDetailsScreen},
-    }, 
+    },
     {
       initialRouteName: ScreenNames.CONTACTS,
       navigationOptions: {


### PR DESCRIPTION
Added the Contact Details page for the Explorer app. 
![image](https://user-images.githubusercontent.com/34689608/43023012-2e61d6f0-8c1e-11e8-9db7-cc4e682c732f.png)

Still need to wire up 'block User' functionality and establishing a shared map. Right now on clicking 'navigate to shared map' redirects to the account holders map only.
Another update needed for 'Last Contact' section which will be tied to the messenger or gps service. 