### PR TITLE
Fix warning in tab navigator & remove unnecessary titles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,4 +2,4 @@ root = true
 
 [*.js]
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,10 @@
       "error",
       "single"
     ],
+    "semi": [
+      "error",
+      "always"
+    ],
     "react/jsx-uses-vars": "warn",
     "react-native/no-unused-styles": 2,
     "react-native/split-platform-components": 2,

--- a/src/app/navigators/main.js
+++ b/src/app/navigators/main.js
@@ -23,10 +23,7 @@ export default createBottomTabNavigator({
     {
       initialRouteName: ScreenNames.CONTACTS,
       navigationOptions: {
-        ...commonStackNavigationOptions,
-        title: 'contacts',
-        tabBarLabel: 'contacts',
-        headerTitle: 'contacts'
+        ...commonStackNavigationOptions
       }
     }
   ),
@@ -38,10 +35,7 @@ export default createBottomTabNavigator({
     {
       initialRouteName: ScreenNames.MAP,
       navigationOptions: {
-        ...commonStackNavigationOptions,
-        title: 'maps',
-        tabBarLabel: 'maps',
-        headerTitle: 'maps'
+        ...commonStackNavigationOptions
       }
     }
   ),
@@ -53,10 +47,7 @@ export default createBottomTabNavigator({
     {
       initialRouteName: ScreenNames.USER_PROFILE,
       navigationOptions: {
-        ...commonStackNavigationOptions,
-        title: 'profile',
-        tabBarLabel: 'profile',
-        headerTitle: 'profile'
+        ...commonStackNavigationOptions
       }
     }
   ),
@@ -64,10 +55,10 @@ export default createBottomTabNavigator({
 {
   initialRouteName: ScreenNames.CONTACTS_TAB,
   navigationOptions: ({navigation}) => ({
-    tabBarIcon: ({tintColor}) => {
+    tabBarIcon: props => {
       const {routeName} = navigation.state;
 
-      return (<NavTabItem routeName={routeName} tintColor={tintColor} />)
+      return (<NavTabItem {...props} routeName={routeName} />);
     },
     title: tabTitles[navigation.state.routeName]
   }),

--- a/src/app/reducers/index.js
+++ b/src/app/reducers/index.js
@@ -1,12 +1,14 @@
 import { combineReducers } from 'redux';
-import settingsData from './settings';
-import userProfileData from './user-profile';
 import navigationData from './navigation';
 import accountData from './account';
+import userProfileData from './user-profile';
+import messagesData from './messages';
+import mapsData from './maps';
 
 export default combineReducers({
   navigationData,
-  settingsData,
+  accountData,
   userProfileData,
-  accountData
+  mapsData,
+  messagesData
 });

--- a/src/app/reducers/maps.js
+++ b/src/app/reducers/maps.js
@@ -1,0 +1,15 @@
+//import ActionTypes from '../actions/types';
+
+let initialState = {
+  mapList: [],
+};
+
+const mapsData = (state = initialState, action) => {
+  switch (action.type) {
+  default:
+    break;
+  }
+  return state;
+};
+
+export default mapsData;

--- a/src/app/reducers/messages.js
+++ b/src/app/reducers/messages.js
@@ -1,0 +1,15 @@
+//import ActionTypes from '../actions/types';
+
+let initialState = {
+  messagesList: []
+};
+
+const messagesData = (state = initialState, action) => {
+  switch (action.type) {
+  default:
+    break;
+  }
+  return state;
+};
+
+export default messagesData;

--- a/src/app/reducers/settings.js
+++ b/src/app/reducers/settings.js
@@ -1,9 +1,0 @@
-//let initialState = {};
-
-const settingsData = (state = {}/*,action*/) => {
-  //initialState = state;
-
-  return state;
-};
-
-export default settingsData;


### PR DESCRIPTION
Fixing the lint warning in the tab navigator, and doing some cleanup of extra declaration in the navigators.  Also, created some new reducers & removed an unneeded one. 

- Updated .editorconfig & .eslint configurations
- Cleaned up unused title declarations in the navigators.
- Created `messages` & `maps` reducers
- Deleted `settings` reducer.