### PR TITLE
Fixed mock map bug, contact & location utilities, and prompt all permission on profile page

### DIFF
--- a/src/app/containers/Contacts/details.js
+++ b/src/app/containers/Contacts/details.js
@@ -8,6 +8,7 @@ import {navigateToMap} from '../../actions/navigation';
 import {capitalizeString} from '../../utilities';
 import commonStyles from '../../common/styles';
 import styles from './styles';
+import {getFullName} from '../../utilities/contacts';
 
 class ContactDetailsScreen extends Component {
   static navigationOptions = () => {
@@ -29,7 +30,7 @@ class ContactDetailsScreen extends Component {
     return (
       <View>
         <View style={styles.mainContainer}>
-          <Text style={[commonStyles.text, styles.titleWrapper]}>{`${contact.firstName} ${contact.lastName}`}</Text>
+          <Text style={[commonStyles.text, styles.titleWrapper]}>{getFullName(contact)}</Text>
           <TouchableOpacity
             style={styles.iconButtonWrapper}
             onPress={() => this._directToMap()}

--- a/src/app/containers/Contacts/index.js
+++ b/src/app/containers/Contacts/index.js
@@ -4,9 +4,9 @@ import {bindActionCreators} from 'redux';
 import { connect } from 'react-redux';
 import { View } from 'react-native';
 import commonStyles from '../../common/styles';
-import { Contacts, Permissions } from 'expo';
 import ContactList from '../../components/ContactList';
 import {navigateToContactDetails} from '../../actions/navigation';
+import {getContactsAsync} from '../../utilities/contacts';
 
 class ContactsScreen extends React.Component {
   static navigationOptions = {
@@ -22,33 +22,10 @@ class ContactsScreen extends React.Component {
   }
 
   async getContacts() {
-    const permission = await Permissions.askAsync(Permissions.CONTACTS);
-    if (permission.status !== 'granted') {
-      return;
-    }
-    const contacts = await Contacts.getContactsAsync({
-      fields: [
-        Contacts.PHONE_NUMBERS,
-        Contacts.EMAILS
-      ]
-    });
-
+    const contacts = await getContactsAsync();
     this.setState({
-      contacts: contacts.data.sort((c1, c2) => {
-        const c1Name = this._getContactFullName(c1).toLowerCase();
-        const c2Name = this._getContactFullName(c2).toLowerCase();
-        if (c1Name < c2Name) {
-          return -1;
-        } else if (c1Name > c2Name) {
-          return 1;
-        }
-        return 0;
-      })
+      contacts
     });
-  }
-
-  _getContactFullName(contact) {
-    return `${contact.firstName} ${contact.lastName}`;
   }
 
   render() {

--- a/src/app/containers/Map/actions.js
+++ b/src/app/containers/Map/actions.js
@@ -1,16 +1,13 @@
 
 import ActionTypes from '../../actions/types';
 
-export function createMap({id, ownerUserID, contactIDs, subject, lastContact, messages = []}) {
+export function createMap({ownerUserID, contactIDs, subject}) {
   return {
     type: ActionTypes.MAP_CREATED,
     map: {
-      id,
       ownerUserID,
       contactIDs,
-      subject,
-      lastContact,
-      messages
+      subject
     }
   };
 }

--- a/src/app/containers/Map/index.js
+++ b/src/app/containers/Map/index.js
@@ -1,7 +1,9 @@
 import React, {Component} from 'react';
 //import PropTypes from 'prop-types';
+import {bindActionCreators} from 'redux';
 import MapComponent from '../../components/Map';
 import {connect} from 'react-redux';
+import {getCurrentPositionAsync} from '../../utilities/location';
 
 class MapScreen extends Component {
   static navigationOptions = () => {
@@ -16,11 +18,10 @@ class MapScreen extends Component {
     this.state = {};
   }
 
-  componentDidMount() {
-    navigator.geolocation.getCurrentPosition(location => {
-      this.setState({
-        userLocation: location.coords
-      });
+  async componentDidMount() {
+    const location = await getCurrentPositionAsync();
+    this.setState({
+      userLocation: location.coords
     });
   }
 
@@ -38,6 +39,6 @@ class MapScreen extends Component {
 MapScreen.propTypes = {};
 
 const mapStateToProps = state => (state);
-const mapDispatchToProps = () => ({});
+const mapDispatchToProps = dispatch => bindActionCreators({}, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(MapScreen);

--- a/src/app/containers/Profile/index.js
+++ b/src/app/containers/Profile/index.js
@@ -12,6 +12,8 @@ import CustomButton from '../../components/Button';
 import {profileUpdated} from './actions';
 import LoadingOverlay from '../../components/LoadingOverlay';
 import {formatNumber} from 'libphonenumber-js';
+import {requestLocationPermissionAsync} from '../../utilities/location';
+import {requestContactsPermissionAsync} from '../../utilities/contacts';
 
 class ProfileScreen extends React.Component {
   static navigationOptions = {
@@ -31,9 +33,14 @@ class ProfileScreen extends React.Component {
     };
   }
 
-  continuePressed() {
+  async continuePressed() {
     const {profileUpdated, navigateToMainFlow} = this.props;
     profileUpdated(this.state.gpsTimeLimit, this.state.displayUserName, this.state.phoneNumber);
+
+    // Prompt user for necessary permissions.
+    await requestContactsPermissionAsync();
+    await requestLocationPermissionAsync();
+
     navigateToMainFlow();
   }
 
@@ -80,7 +87,7 @@ class ProfileScreen extends React.Component {
           />
           <CustomButton
             text="Continue"
-            onPress={this.continuePressed.bind(this)}
+            onPress={() => this.continuePressed()}
             disabled={!this._isProfileValid()}
           />
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -5,6 +5,7 @@ import {AppNavigator} from './navigators';
 import {store, persistor} from './store';
 import { AppLoading, Font } from 'expo';
 import { PersistGate } from 'redux-persist/integration/react';
+import {setupMockMaps} from '../mockData/factories/map';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -33,12 +34,20 @@ export default class App extends React.Component {
     );
   }
 
+  _onPersistedDataLoaded() {
+    setupMockMaps();
+  }
+
   render() {
     const {fontsLoaded} = this.state;
 
     return (
       <Provider store={store}>
-        <PersistGate loading={this._renderAppLoading()} persistor={persistor}>
+        <PersistGate 
+          loading={this._renderAppLoading()}
+          persistor={persistor}
+          onBeforeLift={() => this._onPersistedDataLoaded()}
+        >
           <Layout>
             {fontsLoaded ? (this._renderApp()) : (this._renderAppLoading())}
           </Layout>

--- a/src/app/reducers/account.js
+++ b/src/app/reducers/account.js
@@ -1,7 +1,8 @@
 import ActionTypes from '../actions/types';
+import uuidV4 from 'uuid/v4';
 
 let initialState = {
-  userId: null,
+  userId: uuidV4(),
   country: null,
   countryCode: null,
   phoneNumber: null,

--- a/src/app/reducers/maps.js
+++ b/src/app/reducers/maps.js
@@ -1,18 +1,19 @@
 import ActionTypes from '../actions/types';
+import uuidV4 from 'uuid/v4';
 
 let initialState = {
   mapList: [],
 };
 
-function addMapToState(state, {id, ownerUserID, contactIDs, subject, lastContact, messages}) {
+function addMapToState(state, {ownerUserID, contactIDs, subject}) {
   const {mapList} = state;
   const newMap = {
-    id, // id will be provided by API response
-    ownerUserID, // ownerUserID will be provided in API response
+    id: uuidV4(),
+    ownerUserID,
     contactIDs,
-    lastContact,
     subject,
-    messages
+    lastContact: null,
+    messages: []
   };
   mapList.unshift(newMap);
   return {

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -5,7 +5,6 @@ import rootReducer from './reducers';
 import {navMiddleware} from './navigators';
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
-import {setupMockMaps} from '../mockData/factories/map';
 
 let logger = createLogger({
   timestamps: true,
@@ -23,5 +22,3 @@ export const store = createStore(
   compose(applyMiddleware(thunk, logger, navMiddleware))
 );
 export const persistor = persistStore(store);
-
-setupMockMaps();

--- a/src/app/utilities/contacts.js
+++ b/src/app/utilities/contacts.js
@@ -1,0 +1,86 @@
+
+import { Contacts, Permissions } from 'expo';
+
+/**
+ * async isContactsPermissionGranted
+ * Checks if user has already granted contacts permission.
+ * 
+ * Returns true if permission was granted. false otherwise.
+ */
+export async function isContactsPermissionGrantedAsync() {
+  const {status} = await Permissions.getAsync(Permissions.CONTACTS);
+  return status === 'granted';
+}
+
+/**
+ * async requestContactsPermission
+ * Checks if user has granted contacts permission.  If not, it prompts the 
+ * user to grant permission.  
+ * 
+ * Returns true if permission was granted.  false otherwise.
+ */
+export async function requestContactsPermissionAsync() {
+  // Check if permission was granted already...
+  const isGranted = await isContactsPermissionGrantedAsync();
+  if (isGranted) {
+    return true;
+  }
+  
+  // If permission was not already granted, ask user for permission...
+  const permission = await Permissions.askAsync(Permissions.CONTACTS);
+  return permission.status === 'granted';
+}
+
+/**
+ * async getContacts
+ * Gets contacts from the contacts api.
+ * 
+ * Default behavior:
+ * - sorted: will sort by full name
+ * - checkPermission: will check permission and prompt if they haven't been granted.
+ * 
+ * returns an array of contacts
+ */
+export async function getContactsAsync({sorted=true, checkPermission=true} = {}) {
+  if (checkPermission) {
+    const permissionGranted = await requestContactsPermissionAsync();
+    if (!permissionGranted) {
+      return [];
+    }
+  }
+
+  const contacts = await Contacts.getContactsAsync({
+    fields: [
+      Contacts.PHONE_NUMBERS,
+      Contacts.EMAILS
+    ]
+  });
+  return sorted ? sortContactsByName(contacts.data) : contacts.data;
+}
+
+/**
+ * sortContactsByName
+ * 
+ * sorts the given array of contacts by full name.
+ */
+export function sortContactsByName(contacts = [], {ascending=true} = {}) {
+  return contacts.sort((c1, c2) => {
+    const c1Name = getFullName(c1).toLowerCase();
+    const c2Name = getFullName(c2).toLowerCase();
+    if (c1Name < c2Name) {
+      return ascending ? -1 : 1;
+    } else if (c1Name > c2Name) {
+      return ascending ? 1 : -1;
+    }
+    return 0;
+  });
+}
+
+/**
+ * getFullName
+ * 
+ * Returns the 'full name' for a given contact.
+ */
+export function getFullName(contact = {}) {
+  return `${contact.firstName} ${contact.lastName}`;
+}

--- a/src/app/utilities/location.js
+++ b/src/app/utilities/location.js
@@ -1,0 +1,82 @@
+
+import { Location, Permissions } from 'expo';
+
+/**
+ * async isLocationPermissionGrantedAsync
+ * Checks if user has already granted location permission.
+ * 
+ * Returns true if permission was granted. false otherwise.
+ */
+export async function isLocationPermissionGrantedAsync() {
+  const {status} = await Permissions.getAsync(Permissions.LOCATION);
+  return status === 'granted';
+}
+
+/**
+ * async requestLocationPermissionAsync
+ * Checks if user has granted location permission.  If not, it prompts the 
+ * user to grant permission.  
+ * 
+ * Returns true if permission was granted.  false otherwise.
+ */
+export async function requestLocationPermissionAsync() {
+  // Check if permission was granted already...
+  const isGranted = await isLocationPermissionGrantedAsync();
+  if (isGranted) {
+    return true;
+  }
+  
+  // If permission was not already granted, ask user for permission...
+  const permission = await Permissions.askAsync(Permissions.LOCATION);
+  return permission.status === 'granted';
+}
+
+/**
+ * async getCurrentPositionAsync
+ * Gets the device's current location
+ * 
+ * - enableHighAccuracy (true by default)
+ * 
+ * returns a location object (or null if no permission)
+ * (https://docs.expo.io/versions/v28.0.0/sdk/location#coords-object----the-coordinates-of-the)
+ */
+export async function getCurrentPositionAsync({enableHighAccuracy = true, checkPermission=true} = {}) {
+  if (checkPermission) {
+    const permissionGranted = await requestLocationPermissionAsync();
+    if (!permissionGranted) {
+      return null;
+    }
+  }
+
+  return await Location.getCurrentPositionAsync({enableHighAccuracy});
+}
+
+/**
+ * async watchPositionAsync
+ * Triggers callback whenever location changes based on provided parameters.
+ * 
+ * - checkPermission: whether or not to check GPS permissions first.
+ * - enableHighAccuracy (true by default)
+ * - timeInterval (250ms by default)
+ * - distanceInterval (0.3m (1ft) by default)
+ * - callback: triggered on every location change (will be called with location object)
+ * 
+ * returns a subscription object with a 'remove' function to stop listening.
+ * https://docs.expo.io/versions/v28.0.0/sdk/location#expolocationwatchpositionasyncoptions-callback
+ */
+export async function watchPositionAsync(
+  {checkPermission=true, enableHighAccuracy=true, timeInterval=250, distanceInterval=0.3} = {},
+  callback = () => {}
+) {
+  if (checkPermission) {
+    const permissionGranted = await requestLocationPermissionAsync();
+    if (!permissionGranted) {
+      return null;
+    }
+  }
+
+  return await Location.watchPositionAsync(
+    {enableHighAccuracy, timeInterval, distanceInterval}, 
+    callback
+  );
+}


### PR DESCRIPTION
- Fixed bug where mock data was being created on every launch.
- Created a contact utility to be used whenever we need to fetch contacts (so we don't keep writing the same code over and over)
- Created location utility to be used for getting location data & checking permissions
- Removed unnecessary properties from the `createMap` action.
- Now requesting all permissions after pressing "Continue" on the profile screen.

### NOTE:
After pulling in the code from this PR, delete your expo app before running `npm run ios`.  This is needed to reset the redux state again and clear out all of the maps that were created previously.